### PR TITLE
Correction of condition to test presence of a device

### DIFF
--- a/CDBLEProx.cpp
+++ b/CDBLEProx.cpp
@@ -77,7 +77,7 @@ void CDBLEProximity::update() {
            String mac  = str_token(record,':',4); 
            String rssi = str_token(record,':',5); 
            int temp_rssi = rssi.toInt();
-           if (address!="00000000000000000000000000000000") {
+           if (address=="00000000000000000000000000000000") {
               devices_found++;
                if (temp_rssi > strongest_rssi) {
                   strongest_mac = mac;


### PR DESCRIPTION
as the command AT+DISI? is returning a string like this when a device is detected:
00000000:00000000000000000000000000000000:0000000000:CCXXXCD1A4C:-062
and nothing except OK+DISCE when no device are detected
I think the condition for incrementing devices_found should be == and not !=